### PR TITLE
Add support for ini files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "vscode-sops" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+### Added
+- Support for `ini` files
+
 ## [0.1.2]
 ### Fixed
 - Relative paths for `gcpCredentialsPath` option.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The homepage of VSCode extension is located on https://github.com/signageos/vsco
 ## Features
 
 VSCode extension with underlying [SOPS](https://github.com/mozilla/sops) supports:
-- Realtime editing of encrypted yaml/json files in-place in your project.
+- Realtime editing of encrypted `yaml`, `json` and `ini` files in-place in your project.
 - Create new encrypted yaml/json file using `.sops.yaml` config creation_rules if available.
 
 ## Requirements

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,12 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/ini": {
+			"version": "1.3.30",
+			"resolved": "https://registry.npmjs.org/@types/ini/-/ini-1.3.30.tgz",
+			"integrity": "sha512-2+iF8zPSbpU83UKE+PNd4r/MhwNAdyGpk3H+VMgEH3EhjFZq1kouLgRoZrmIcmoGX97xFvqdS44DkICR5Nz3tQ==",
+			"dev": true
+		},
 		"@types/json-schema": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -1080,6 +1086,11 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "7.0.4",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"@types/debug": "4.1.5",
 		"@types/fs-extra": "8.1.0",
 		"@types/glob": "^7.1.1",
+		"@types/ini": "^1.3.30",
 		"@types/mocha": "^7.0.1",
 		"@types/node": "^12.11.7",
 		"@types/text-encoding": "0.0.35",
@@ -96,6 +97,7 @@
 	"dependencies": {
 		"debug": "4.1.1",
 		"fs-extra": "8.1.0",
+		"ini": "1.3.5",
 		"text-encoding": "0.7.0",
 		"yaml": "1.7.2"
 	}


### PR DESCRIPTION
`sops` can encrypt `INI` files as well. This PR is just quickly adding support for this file type, nothing fancy.

Introducing a new dependency: https://github.com/npm/ini