### PR TITLE
Remove node.js requirement with using only shell in fake editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 - Occasionally not decrypting sops file when it was already encrypted early before
+- Remove requirement on globally installed node.js
 
 ## [0.2.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ VSCode extension with underlying [SOPS](https://github.com/mozilla/sops) support
 
 - Tutorial to SOPS: https://www.youtube.com/watch?v=V2PRhxphH2w
 
-- For encryption of file back after changes, you have to have [Node.js](https://nodejs.org/en/) installed on your PC (`node` bin in your `$PATH`)
-
 ## Extension Settings
 * `sops.enable`: enable/disable this extension (default: true)
 * `sops.binPath`: Path to SOPS binary (default: executables from `$PATH`)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,9 +22,8 @@ const debug = Debug(DEBUG_NAMESPACE);
 const convertUtf8ToUint8Array = (input: string) => new TextEncoder("utf-8").encode(input);
 const convertUint8ArrayToUtf8 = (input: Uint8Array) => new TextDecoder("utf-8").decode(input);
 
-const FAKE_DECRYPTED_EDITOR_NODE = `#!/usr/bin/env node
-const fs = require('fs');
-fs.writeFileSync(process.argv[2], fs.readFileSync(process.env.VSCODE_SOPS_DECRYPTED_FILE_PATH));
+const FAKE_DECRYPTED_EDITOR_SHELL = `#!/bin/sh
+cat $VSCODE_SOPS_DECRYPTED_FILE_PATH > $1
 `;
 
 const CONFIG_BASE_SECTION = 'sops';
@@ -278,7 +277,7 @@ async function getEncryptedFileContent(uri: vscode.Uri, originalEncryptedUri: vs
 	const tmpEncryptedFilePath = path.join(os.tmpdir(), await getChecksum(Math.random().toString()));
 	const tmpFakeDecryptedEditorPath = path.join(os.tmpdir(), await getChecksum(Math.random().toString()));
 	try {
-		await fs.writeFile(tmpFakeDecryptedEditorPath, FAKE_DECRYPTED_EDITOR_NODE, { mode: 0o755 }); // TODO add Win .cmd script detection
+		await fs.writeFile(tmpFakeDecryptedEditorPath, FAKE_DECRYPTED_EDITOR_SHELL, { mode: 0o755 }); // TODO add Win .cmd script detection
 		await fs.writeFile(tmpDecryptedFilePath, decryptedContent, { mode: 0o600 });
 		await fs.writeFile(tmpEncryptedFilePath, originalEncryptedContent, { mode: 0o600 });
 		debug('Encrypting', uri.path, decryptedContent);


### PR DESCRIPTION
* node.js is not neccesary. The logic for storing new encrypted file is done using simple shell script.

Closes #18