### PR TITLE
fix(windows): Modify decrypt file path to support native Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "vscode-sops" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.4.1]
+### Fixed
+- Fix decrypt file paths to support native windows environments
+
 ## [0.4.0]
 ### Added
 - Support to parse even multiple yaml declarations in a single YAML file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "signageos-vscode-sops",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "@signageos/vscode-sops",
 	"description": "",
 	"publisher": "signageos",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/signageos/vscode-sops"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -535,7 +535,7 @@ function isDecryptedFile(uri: vscode.Uri) {
 function getDecryptedFileUri(encryptedUri: vscode.Uri): vscode.Uri {
 	const decryptedFileName = DECRYPTED_PREFIX + path.basename(encryptedUri.path);
 	const decryptedFilePath = path.join(path.dirname(encryptedUri.path), decryptedFileName);
-	const decryptedFileUri = encryptedUri.with({ path: decryptedFilePath });
+	const decryptedFileUri = encryptedUri.with({ path: decryptedFilePath.replace(/\\/g, "/") });
 	return decryptedFileUri;
 }
 


### PR DESCRIPTION
There seems to be some sort of an odd bug with the vscode API `uri.with()` method where when it is used in a native Windows environment with paths that contain backslashes (`\`), it prepends the path being added with a `/`.  The leading `/` causes ts to throw unknown errors when it tries to interact with the file (as described in #13).

Example path created by the extension when running  on windows using the existing 0.4.0 code:
`'/\\d:\\sops-folder\\secrets\\.decrypted~creds.yaml'`

Example path created using this change:
`/d:/sops-folder/secrets/.decrypted~creds.yaml`

When the path being passed to `.with()` has been modified to remove all backslashes, `.with()` no longer prepends the path with a `/` and the resulting path works correctly with the ts filesystem functions.

This change should not cause any problems when running on *nix as backslashes should never exist in paths there.
