### PR TITLE
Added ignore MAC option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ VSCode extension with underlying [SOPS](https://github.com/mozilla/sops) support
 * `sops.defaults.gcpCredentialsPath`: Default path used to find GCP credentials. Overrides the `$GOOGLE_APPLICATION_CREDENTIALS` environment variable (empty: defaults to environment variable `$GOOGLE_APPLICATION_CREDENTIALS`)
 * `sops.defaults.ageKeyFile`: Default path used to find AGE key file. Overwrites the `$SOPS_AGE_KEY_FILE` environment variable (default: uses from environment variable `$SOPS_AGE_KEY_FILE`)
 * `sops.creationEnabled`: enable/disable this extension to try encrypt files included in .sops.yaml path_regex when is not encrypted yet (default: false)
+* `sops.ignoreMac`: enable/disable MAC verification
 
 ## Config file
 > Named `.sopsrc` in project root by default and is in YAML format.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,12 @@
 					"type": "string",
 					"scope": "resource",
 					"description": "Default path used to find AGE key file. Overwrites the `$SOPS_AGE_KEY_FILE` environment variable (default: uses from environment variable `$SOPS_AGE_KEY_FILE`)"
+				},
+				"sops.defaults.ignoreMac": {
+					"type": "boolean",
+					"scope": "resource",
+					"default": false,
+					"description": "enable/disable MAC verification (default: false)"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ enum ConfigName {
 	defaultGcpCredentialsPath = 'defaults.gcpCredentialsPath',
 	defaultAgeKeyFile = 'defaults.ageKeyFile',
 	configPath = 'configPath', // Run Control path
+	ignoreMac = "ignoreMac",
 }
 interface IRunControl {
 	awsProfile?: string;
@@ -516,6 +517,7 @@ async function getSopsGeneralOptions() {
 	const defaultAwsProfile: string | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.defaultAwsProfile);
 	const defaultGcpCredentialsPath: string | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.defaultGcpCredentialsPath);
 	const defaultAgeKeyFile: string | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.defaultAgeKeyFile);
+	const defaultIgnoreMac: boolean | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.ignoreMac);
 	debug('config', { defaultAwsProfile, defaultGcpCredentialsPath, defaultAgeKeyFile });
 	const rc = await getRunControl();
 	const awsProfile = rc.awsProfile ?? defaultAwsProfile;
@@ -528,6 +530,10 @@ async function getSopsGeneralOptions() {
 	if (awsProfile) {
 		sopsGeneralArgs.push('--aws-profile', awsProfile);
 		sopsGeneralEnvVars[AWS_PROFILE_ENV_VAR_NAME] = awsProfile; // --aws-profile argument doesn't work well
+	}
+
+	if (defaultIgnoreMac) {
+		sopsGeneralArgs.push('--ignore-mac');
 	}
 
 	if (gcpCredentialsPath) {
@@ -809,4 +815,4 @@ export function activate(context: vscode.ExtensionContext) {
 	updateSubscriptions();
 }
 
-export function deactivate() {}
+export function deactivate() { }


### PR DESCRIPTION
Content may be changed, without regenerating MAC. SOPS have option `--ignore-mac` before opening, it's allow correctly open changed config/secret