### PR TITLE
feat: permit running with sops via aqua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "vscode-sops" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.9.0]
+### Added
+- Execute `sops` command in directory with .sops.yaml corresponding to file to decrypt/encrypt. (This permit support sops via [aquaproj/aqua](https://aquaproj.github.io/))
+
 ## [0.8.0]
 ### Added
 - Support for `binary` files (`octet-stream` mime type, `.bin` extension)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ VSCode extension with underlying [SOPS](https://github.com/mozilla/sops) support
 - Realtime editing of encrypted `yaml`, `json`, `dotenv`, `plaintext`, `binary` and `ini` files in-place in your project.
 - Create new encrypted yaml/json file using `.sops.yaml` config creation_rules if available.
 
+This extension works with binaries `sops / age / ...` installed via [aquaproj/aqua](https://aquaproj.github.io/).
+
 ## Requirements
 
 - Download and install SOPS from here: https://github.com/mozilla/sops/releases


### PR DESCRIPTION
[aqua ](https://aquaproj.github.io/docs/) is a declarative CLI Version Manager written in Go. You can manage tool versions with YAML.

This tool permit to define different sops version through repositories. (show https://aquaproj.github.io/docs/tutorial/change-version-per-project)

However, to benefit from this tool, it is necessary that the commands executed through Aqua are done from a directory that has (or one of its parents has) an aqua.yaml configuration file with the declaration of these packages. (https://aquaproj.github.io/docs/tutorial/config-path/)

So when i use your extension, without sops installed "globally" (/usr/local/bin for example), i can't decrypt or encrypt file.

This is the first time I'm trying to modify the code of a VSCode extension, and it's really challenging to debug. Additionally, I've never worked with JavaScript before, so there might be things to review. Don't hesitate!

However, I've tried to keep the code to a minimum to enable the functionality of this extension with Sops via Aqua without breaking existing functionality. I hope this works for you!

Thank you.
