### PR TITLE
fix(extension): adapt for windows OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to the "vscode-sops" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.9.1]
+### Fixed
+- Fixed functionality issues in version 0.9.0 for Windows systems.
+
 ## [0.9.0]
+### Warning
+- This version is not working on Windows systems. Please use version 0.9.1 instead.
+
 ### Added
 - Execute `sops` command in directory with .sops.yaml corresponding to file to decrypt/encrypt. (This permit support sops via [aquaproj/aqua](https://aquaproj.github.io/))
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -561,11 +561,17 @@ async function getSopsGeneralOptions(fileUriToEncryptOrDecrypt: vscode.Uri) {
 
 	// Error related to this issue https://github.com/getsops/sops/issues/884 is thrown otherwise.
 	// This is a workaround until the issue is fixed.
-	sopsGeneralArgs.push('--config', '/dev/null');
+	let configPath = os.platform() === 'win32' ? 'NUL' : '/dev/null';
+	sopsGeneralArgs.push('--config', configPath);
 
 	let sopsConfigUri = await findSopsConfigRecursive(fileUriToEncryptOrDecrypt.with({ path: path.dirname(fileUriToEncryptOrDecrypt.path) }));
 	if (sopsConfigUri) {
-		spawnOptions.cwd = path.dirname(sopsConfigUri.path);
+		let sopsConfigPath = sopsConfigUri.path;
+		if (os.platform() === 'win32') {
+			// remove first '/' character of path on windows /c:/foo/bar ==> c:/foo/bar
+			sopsConfigPath = sopsConfigPath.substring(1);
+		}
+		spawnOptions.cwd = path.dirname(sopsConfigPath);
 	}
 
 


### PR DESCRIPTION

As reported in [this issue](https://github.com/signageos/vscode-sops/pull/73), users operating on Windows systems were unable to use version 0.9.0 of this extension due to the changes introduced in that pull request.

This new update resolves the issue for Windows users.