### PR TITLE
feat: add support for mac-only-encrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This extension works with binaries `sops / age / ...` installed via [aquaproj/aq
 * `sops.defaults.ageKeyFile`: Default path used to find AGE key file. Overwrites the `$SOPS_AGE_KEY_FILE` environment variable (default: uses from environment variable `$SOPS_AGE_KEY_FILE`)
 * `sops.creationEnabled`: enable/disable this extension to try encrypt files included in .sops.yaml path_regex when is not encrypted yet (default: false)
 * `sops.ignoreMac`: enable/disable MAC verification
+* `sops.macOnlyEncrypted`: compute MAC only over values which end up encrypted
 
 ## Config file
 > Named `.sopsrc` in project root by default and is in YAML format.

--- a/package.json
+++ b/package.json
@@ -87,6 +87,12 @@
 					"scope": "resource",
 					"default": false,
 					"description": "enable/disable MAC verification (default: false)"
+				},
+				"sops.defaults.macOnlyEncrypted": {
+					"type": "boolean",
+					"scope": "resource",
+					"default": false,
+					"description": "compute MAC only over values which end up encrypted (default: false)"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ enum ConfigName {
 	defaultAgeKeyFile = 'defaults.ageKeyFile',
 	configPath = 'configPath', // Run Control path
 	ignoreMac = "ignoreMac",
+	macOnlyEncrypted = "macOnlyEncrypted",
 }
 interface IRunControl {
 	awsProfile?: string;
@@ -518,6 +519,7 @@ async function getSopsGeneralOptions(fileUriToEncryptOrDecrypt: vscode.Uri) {
 	const defaultGcpCredentialsPath: string | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.defaultGcpCredentialsPath);
 	const defaultAgeKeyFile: string | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.defaultAgeKeyFile);
 	const ignoreMac: boolean | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.ignoreMac);
+	const macOnlyEncrypted: boolean | undefined = vscode.workspace.getConfiguration(CONFIG_BASE_SECTION).get(ConfigName.macOnlyEncrypted);
 	debug('config', { defaultAwsProfile, defaultGcpCredentialsPath, defaultAgeKeyFile });
 	const rc = await getRunControl();
 	const awsProfile = rc.awsProfile ?? defaultAwsProfile;
@@ -535,6 +537,10 @@ async function getSopsGeneralOptions(fileUriToEncryptOrDecrypt: vscode.Uri) {
 	if (ignoreMac) {
 		sopsGeneralArgs.push('--ignore-mac');
 	}
+
+	if (macOnlyEncrypted) {
+		sopsGeneralArgs.push('--mac-only-encrypted');
+	}	
 
 	if (gcpCredentialsPath) {
 		if (!path.isAbsolute(gcpCredentialsPath) && vscode.workspace.workspaceFolders) {


### PR DESCRIPTION
In some cases the `--ignore-mac` doesn't seem to be working as the vscode-sops plugin shows the following error:

```
Could not decrypt SOPS file test.enc.yaml: Could not decrypt file: test.enc.yaml, MAC mismatch. File has XXX, computed YYY
```

To prevent that, it would probably be best to allow the usage of `--mac-only-encrypted`.  This should allow edits to the file and only get mismatches in case the encrypted values have changed rather than the entire file (e.g. by renovate, which doesn't do anything with sops/age)

From the `sops` help:

```shell
   --mac-only-encrypted                     compute MAC only over values which end up encrypted
```

This PR adds an optional setting (default `false`) to pass along the `--mac-only-encrypted` argument to the sops binary.